### PR TITLE
fix: typo, decription to description

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
 outputs:
   automatic_releases_tag:
-    decription: "The release tag this action just processed"
+    description: "The release tag this action just processed"
 runs:
   using: "node12"
   main: "dist/index.js"


### PR DESCRIPTION
Awesome action - Thanks!

I've started getting these in my workflows today for every run:

```shell
##[error]marvinpinto/action-automatic-releases/v1.0.0/action.yml (Line: 27, Col: 5): Unexpected value 'decription'
##[error]marvinpinto/action-automatic-releases/v1.0.0/action.yml (Line: 27, Col: 5): Unexpected value 'decription'
##[error]Fail to load marvinpinto/action-automatic-releases/v1.0.0/action.yml
```

I'm guessing GitHub started validating these action files today or something.