### PR TITLE
Update node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ outputs:
   upload_url:
     description: "The URL for uploading additional assets to the release"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "git-merge"


### PR DESCRIPTION
As node 12 has been deprecated and Github is looking to upgrade all github actions to node 16 (more https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ ) this commit will update the node version used.