### PR TITLE
Name of a tag defaults to github.ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ jobs:
 | `repo_token`\*\*        | GitHub Action token, e.g. `"${{ secrets.GITHUB_TOKEN }}"`. | `null`   |
 | `draft`                 | Mark this release as a draft?                              | `false`  |
 | `prerelease`            | Mark this release as a pre-release?                        | `true`   |
-| `automatic_release_tag` | Tag name to use for automatic releases, e.g `latest`.      | `null`   |
+| `automatic_release_tag` | Tag name to use for automatic releases, e.g `latest`.      | github.ref |
 | `title`                 | Release title; defaults to the tag name if none specified. | Tag Name |
 | `files`                 | Files to upload as part of the release assets.             | `null`   |
 


### PR DESCRIPTION
This also should prevent creating a new release and simply upload the assets to the existing release to support repositories that create the release manually but also want to use this action.

Currently when using github.ref as tag name it shows the following error:
```
...
Generating release tag
  Attempting to create or update release tag "refs/tags/1.9"
  Could not create new tag "refs/tags/refs/tags/1.9" (Sorry, branch or tag names starting with 'refs/' are not allowed.) therefore updating existing tag "tags/refs/tags/1.9"
  Error: Reference does not exist
  D:\a\_actions\marvinpinto\action-automatic-releases\latest\dist\index.js:1
...
```